### PR TITLE
Don't make the user think

### DIFF
--- a/WebsiteAndApi/index.html
+++ b/WebsiteAndApi/index.html
@@ -71,7 +71,7 @@
 
 		<article>
 			<h1>Call for Sponsors Open</h1>
-			<p>The call for sponsors is officially open. Go to the sponsors page for more information.</p>
+			<p>The call for sponsors is officially open. Go to <a href="sponsors.html">the sponsors page</a> for more information.</p>
 		</article>
 	</section>
 


### PR DESCRIPTION
Link to the Sponsorship page in the text telling users to go to
the Sponsorship page instead of making them scroll and hunt.